### PR TITLE
breaking change: default to buffering all HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 HTTP Watcher Module
 ============================
 
-This is initially based on the concept described in [Authentication in AngularJS (or similar) based application](http://www.espeo.pl/1-authentication-in-angularjs-application/) and  - https://github.com/witoldsz/angular-http-auth
+This is initially based on the concept described in [Authentication in
+AngularJS (or similar) based application](http://www.espeo.pl/1-authentication-in-angularjs-application/)
+and https://github.com/witoldsz/angular-http-auth
 
-But we extended it to be a general notification (and buffering) system for all http requests an angular app does via the `$http` service.
+But we extended it to be a general notification (and buffering) system for all
+http requests an angular app does via the `$http` service.
 
 Usage
 ------
@@ -20,8 +23,11 @@ This module installs $http interceptor and provides the `httpWatcher` service.
 
 The $http interceptor does the following:
 
-If an HTTP request fails, the event `network:http-error` is broadcasted with the configuration object (this is the requested URL, payload and parameters)
-of said request. If the HTTP Error-Code is in the bufferList, it will be buffered and can be replayed at any given time using the `continue()` method of the `httpWatcher` service.
+If an HTTP request fails, the event `network:http-error` is broadcasted with
+the configuration object (this is the requested URL, payload and parameters) of
+said request. If the HTTP Error-Code is in the bufferList, it will be buffered
+and can be replayed at any given time using the `continue()` method of the
+`httpWatcher` service.
 
 You are responsible to invoke this method after you handled the error. Example:
 ```js
@@ -33,17 +39,25 @@ return function(httpWatcher) {
 
 #### Ignoring the interceptor
 
-Sometimes you might not want the interceptor to intercept a request even if one returns a http error code. In a case like this you can add `ignoreHttpWatcher: true` to the request config.
+Sometimes you might not want the interceptor to intercept a request even if one
+returns a http error code. In a case like this you can add `ignoreHttpWatcher:
+true` to the request config.
 
 #### Disabling the buffering of requests
 
-If needed, you can also add `saveOnHttpError: false|true` to the request config to specifically say you want to allow/disallow buffering a request regardless of the response code.
+If needed, you can also add `saveOnHttpError: false|true` to the request config
+to specifically say you want to allow/disallow buffering a request regardless
+of the response code.
 
-#### Specifing custom default values
+#### Configuration
 
-If you need a custom event name oder you want to change the defaults which http statuses are saved and which not in your app, you can do this easily by using the ``httpWatcherConfig`` provider in your app. On initialization this will be used by the interceptor.
+If you need a custom event name oder you want to change the defaults which http
+statuses are saved and which not in your app, you can do this easily by using
+the ``httpWatcherConfig`` provider in your app. On initialization this will be
+used by the interceptor.
 
-Currently support are these values, shown with their default values, all optional:
+This will look roughly like this:
+
 ```js
 angular.module('your-app', []).config(function(httpWatcherConfigProvider) {
   httpWatcherConfigProvider.setConfig({
@@ -53,10 +67,16 @@ angular.module('your-app', []).config(function(httpWatcherConfigProvider) {
       reject: 'network:reject'
     },
     status: {
-      0: true,
-      408: true,
-      401: true
+      401: false,
     }
   });
 });
 ```
+
+* `eventNames` just specify the names of the events thrown (all optional,
+  default values shown above)
+* The `status` object contains a map of HTTP status codes to a boolean
+  indicating if those request should be saved.
+  * Setting, e.g. `401: false`, like shown above means that requests resulting in
+    a 401 won't be buffered.
+  * The default is to buffer all requests.

--- a/src/config.js
+++ b/src/config.js
@@ -5,11 +5,7 @@ module.exports = function() {
       continue: 'network:continue',
       reject: 'network:reject'
     },
-    status: {
-      0: true,
-      408: true,
-      401: true
-    }
+    status: {}
   };
 
   this.getConfig = function() {

--- a/src/interceptor.js
+++ b/src/interceptor.js
@@ -17,7 +17,7 @@ module.exports = function($httpProvider) {
     return {
       responseError: function(rejection) {
         if (!rejection.config.ignoreHttpWatcher) {
-          var storeRequest = config.status[rejection.status] || false;
+          var storeRequest = config.status[rejection.status] || true;
 
           if (angular.isDefined(rejection.config.saveOnHttpError)) {
             storeRequest = rejection.config.saveOnHttpError;


### PR DESCRIPTION
The former default was to _not_ buffer them. Can still be set via the config (`status` key).

Rationale: The whole `continue` thing is basically the main part about this - and it's off by default except for 401 and 408.

(README updated and line-wrapped - view rich-text diff)

Should be tagged as 3.0.0